### PR TITLE
bug(schema): Add "additionalProperties" false

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -274,5 +274,6 @@
         "temperature",
         "final_weight",
         "stages"
-    ]
+    ],
+    "additionalProperties": false
 }


### PR DESCRIPTION
Currently, our schema doesn't validate that extra properties are included in our JSON schema. 

This usually isn't a problem if we are creating a new profile from the app. However, community sites allows you to upload a custom JSON. Some of these JSONs include fields that are not allowed on the Meticulous.

We convert these JSONs into machine code by hashing, and if the machine sees these fields, they will not run, even though it would "pass" the validation process. Adding "additionalProperties": false will fail the validation process.