### PR TITLE
SW-20: Mismatch Between Mobile App Label and Profile Comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,24 @@ This repo contains an example profile and a json schema for the meticulous profi
 
 rfc.md contains a super dirty explanation which is a) unfinished and b) only public to serve as a basis for discussion.
 A final and dependable version will be marked as such!
+
+## Exit-trigger comparisons
+
+Exit triggers support four comparison values, each with its own boundary
+semantics:
+
+- `>` activates only when the monitored value is strictly above the threshold.
+- `<` activates only when the monitored value is strictly below the threshold.
+- `>=` activates when the monitored value equals or exceeds the threshold.
+- `<=` activates when the monitored value equals or falls below the threshold.
+
+The `comparison` field remains optional. When it is omitted, consumers use
+`>=` for compatibility with existing profiles. Explicit comparison values are
+preserved as written; none of the four supported values is deprecated or
+migrated to another value.
+
+Run the dependency-free repository contract check with PowerShell:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ./tests/validate-contract.ps1
+```

--- a/rfc.md
+++ b/rfc.md
@@ -165,7 +165,7 @@ Variables are to be set prior to the start of the brewing process and can theref
     - **type**: The kind of condition to monitor (e.g., "weight," "pressure," "time"), directing the machine on what sensor feedback or internal timer to evaluate.
     - **value**: The specific threshold that activates the trigger, indicating when the stage's goal has been achieved or a certain limit has been reached.
     - **relative**: (Optional) A boolean indicating whether the trigger's value is relative to the start of the stage or absolute.
-    - **comparison**: (Optional) Specifies whether the trigger activates when the monitored value is "greater" or "less" than the specified value, adding flexibility in defining exit conditions.
+    - **comparison**: (Optional) Specifies whether the trigger activates when the monitored value is strictly greater than (`>`), strictly less than (`<`), greater than or equal to (`>=`), or less than or equal to (`<=`) the specified value. Each explicit operator preserves its own boundary semantics. When omitted, consumers use `>=` for compatibility.
 
 - **limits**: (Optional) Constraints applied to parameters within the stage to prevent exceeding the machine's capabilities or safety thresholds. Each limit specifies:
     - **type**: The parameter to constrain (e.g., "flow," "pressure"), ensuring that the stage does not push the machine beyond safe operational bounds.

--- a/schema.json
+++ b/schema.json
@@ -212,7 +212,17 @@
                                 },
                                 "comparison": {
                                     "type": "string",
+                                    "description": "Comparison applied to the exit-trigger value. Explicit '>', '<', '>=', and '<=' values preserve their strict or inclusive semantics. When omitted, consumers use '>=' for compatibility.",
+                                    "default": ">=",
                                     "enum": [
+                                        ">",
+                                        "<",
+                                        ">=",
+                                        "<="
+                                    ],
+                                    "examples": [
+                                        ">",
+                                        "<",
                                         ">=",
                                         "<="
                                     ]

--- a/tests/validate-contract.ps1
+++ b/tests/validate-contract.ps1
@@ -1,0 +1,90 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$schemaPath = Join-Path $repositoryRoot "schema.json"
+$examplePath = Join-Path $repositoryRoot "example_profile.json"
+
+$schema = Get-Content -Raw -LiteralPath $schemaPath | ConvertFrom-Json
+$exampleJson = Get-Content -Raw -LiteralPath $examplePath
+$example = $exampleJson | ConvertFrom-Json
+
+$comparisonSchema = $schema.properties.stages.items.properties.exit_triggers.items.properties.comparison
+$expectedComparisons = @(">", "<", ">=", "<=")
+$actualComparisons = @($comparisonSchema.enum)
+
+if (Compare-Object -ReferenceObject $expectedComparisons -DifferenceObject $actualComparisons) {
+    throw "The comparison enum must accept exactly '>', '<', '>=', and '<=' without aliases."
+}
+
+if ($comparisonSchema.default -ne ">=") {
+    throw "An omitted comparison must retain the existing '>=' compatibility behavior."
+}
+
+$triggerRequiredFields = @($schema.properties.stages.items.properties.exit_triggers.items.required)
+if ($triggerRequiredFields -contains "comparison") {
+    throw "The comparison field must remain optional."
+}
+
+function Test-ComparisonValidity {
+    param(
+        [AllowNull()]
+        [object]$Comparison
+    )
+
+    return $null -eq $Comparison -or $actualComparisons -contains $Comparison
+}
+
+foreach ($comparison in $expectedComparisons) {
+    if (-not (Test-ComparisonValidity -Comparison $comparison)) {
+        throw "Supported comparison '$comparison' was rejected."
+    }
+}
+
+if (-not (Test-ComparisonValidity -Comparison $null)) {
+    throw "An omitted comparison was rejected."
+}
+
+foreach ($unsupportedComparison in @("==", "!=", "=>", "=<", "greater")) {
+    if (Test-ComparisonValidity -Comparison $unsupportedComparison) {
+        throw "Unsupported comparison '$unsupportedComparison' was accepted."
+    }
+}
+
+$numericTriggerTypes = @("weight", "time", "pressure", "flow", "piston_position", "power")
+
+foreach ($triggerType in $numericTriggerTypes) {
+    foreach ($comparison in $expectedComparisons) {
+        $trigger = [ordered]@{
+            type = $triggerType
+            value = 1
+            relative = $false
+            comparison = $comparison
+            unrelated = "preserve-me"
+        }
+        $beforeValidation = $trigger | ConvertTo-Json -Compress
+
+        if (-not (Test-ComparisonValidity -Comparison $trigger.comparison)) {
+            throw "The '$triggerType' trigger rejected supported comparison '$comparison'."
+        }
+
+        $afterValidation = $trigger | ConvertTo-Json -Compress
+        if ($afterValidation -cne $beforeValidation) {
+            throw "Validating '$triggerType' with '$comparison' rewrote profile data."
+        }
+    }
+}
+
+$exampleBeforeValidation = $example | ConvertTo-Json -Depth 100 -Compress
+foreach ($trigger in @($example.stages | ForEach-Object { $_.exit_triggers })) {
+    if (-not (Test-ComparisonValidity -Comparison $trigger.comparison)) {
+        throw "The repository example contains unsupported comparison '$($trigger.comparison)'."
+    }
+}
+$exampleAfterValidation = $example | ConvertTo-Json -Depth 100 -Compress
+
+if ($exampleAfterValidation -cne $exampleBeforeValidation) {
+    throw "Contract validation rewrote the example profile."
+}
+
+Write-Output "Comparator contract validation passed."


### PR DESCRIPTION
Expanded the optional exit-trigger comparison contract to support >, <, >=, and <= as distinct values. Documented exact semantics and the omitted >= compatibility fallback. Added focused non-mutating contract coverage; no migration or canonicalization was introduced.

Linear: https://linear.app/meticulous-home/issue/SW-20/mismatch-between-mobile-app-label-and-profile-comparator

> Draft created by the local agent orchestrator. Human approval and merge are required.